### PR TITLE
docs: full markdown audit — strip WhatsApp, fix stale content, correct fabrications

### DIFF
--- a/data/presets/workspaces/default/AGENTS.md
+++ b/data/presets/workspaces/default/AGENTS.md
@@ -9,7 +9,6 @@ Personal AI assistant and system automation agent for ClawOS.
 - Search the web (when online) or report offline gracefully
 - Remember and recall facts across sessions
 - Speak and listen via voice pipeline
-- Receive and respond to WhatsApp messages
 - Approve or deny tool calls based on policy
 
 ## What you must never do

--- a/data/presets/workspaces/default/HEARTBEAT.md
+++ b/data/presets/workspaces/default/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 ## What is this?
 This file defines what Nexus checks proactively, on a schedule, without being asked.
-Results are pushed to WhatsApp (if connected) or logged to HISTORY.md.
+Results are logged to HISTORY.md and surfaced in the dashboard.
 
 ## How to use
 Add tasks in this format:

--- a/data/presets/workspaces/default/IDENTITY.md
+++ b/data/presets/workspaces/default/IDENTITY.md
@@ -12,7 +12,6 @@ All processing happens on-device — nothing leaves your network.
 | Channel   | Style                                       | Max response length |
 |-----------|---------------------------------------------|---------------------|
 | voice     | Conversational, short sentences, no markdown | 2–3 sentences       |
-| whatsapp  | Casual, direct, emoji OK                    | 3–5 sentences       |
 | dashboard | Structured, markdown OK, detailed           | Unrestricted        |
 | workbench | Technical, precise, cite sources            | Unrestricted        |
 | default   | Helpful, clear, concise                     | 5–8 sentences       |

--- a/data/presets/workspaces/default/SOUL.md
+++ b/data/presets/workspaces/default/SOUL.md
@@ -10,7 +10,7 @@ ClawOS is the OS/platform you run on. It includes several runtimes and tools:
 - **PicoClaw**: a lightweight background worker runtime for cost-zero agentic tasks, runs alongside you
 - **OpenClaw**: a SEPARATE third-party tool (like Claude Code or an AI agent framework) with 13,700+ skills/plugins. It is NOT ClawOS. It can be installed on ClawOS but is its own product. When the user says "OpenClaw" they mean this external tool, NOT ClawOS itself.
 - **Ollama**: the local model server running your LLM (currently qwen2.5:7b)
-- **clawd/gatewayd**: ClawOS system services (orchestration layer, WhatsApp bridge)
+- **clawd**: ClawOS orchestration service (hardware detection, scheduler, service lifecycle)
 
 When a user asks about "OpenClaw", always treat it as the external third-party tool described above, never confuse it with ClawOS.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -6,7 +6,7 @@ Three flagship demos that prove offline AI can be magical on your own laptop.
 
 ## Demo 1: Morning Briefing (Voice-First)
 
-**What it does:** Say "Hey JARVIS" → Get a spoken morning briefing with weather, calendar, and tasks.
+**What it does:** Say "Hey Claw" → Get a spoken morning briefing with weather, calendar, and tasks.
 
 **How to try it:**
 ```bash

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -471,5 +471,5 @@ security:
 
 ---
 
-**Version:** ClawOS 0.1.0  
-**Last Updated:** April 27, 2026
+**Version:** ClawOS 0.1.1  
+**Last Updated:** April 30, 2026

--- a/docs/ARCHITECTURE_CURRENT.md
+++ b/docs/ARCHITECTURE_CURRENT.md
@@ -6,7 +6,7 @@ ClawOS is best understood as a local-first agent platform with service-shaped mo
 
 ## Canonical Runtime Path
 
-1. User input enters through `nexus`, `clawctl`, dashboard APIs, WhatsApp, or A2A.
+1. User input enters through `nexus`, `clawctl`, dashboard APIs, voice, or A2A.
 2. `agentd` owns task submission, session reuse, and the local HTTP API.
 3. `AgentRuntime` builds context, chooses tools, and talks to Ollama.
 4. `toolbridge` runs tools after a `policyd` check.
@@ -34,7 +34,6 @@ input/channel -> agentd -> AgentRuntime -> policyd -> toolbridge -> local system
 ## Supporting Components
 
 - `services/modeld/service.py`: model inventory, health, profile selection, and VRAM helpers.
-- `services/gatewayd/service.py`: WhatsApp bridge and peer delegation entry points.
 - `services/a2ad/service.py`: agent card, peer discovery, and trusted-peer A2A API.
 - `workflows/`: a mix of agent-backed prompts and direct Python helpers with platform metadata.
 - `openclaw_integration/`: installer and configuration bridge for the OpenClaw ecosystem.

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -6,7 +6,7 @@ Complete guide for deploying ClawOS in various environments.
 
 ```bash
 # 1. Clone repository
-git clone https://github.com/openclaw/clawos.git
+git clone https://github.com/xbrxr03/clawos.git
 cd clawos
 
 # 2. Install dependencies

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -431,5 +431,5 @@ Complete list of all implemented features in ClawOS.
 
 ---
 
-**Last Updated**: 2026-04-27
-**Version**: 0.1.0-beta
+**Last Updated**: 2026-04-30
+**Version**: 0.1.1

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -17,7 +17,6 @@ ClawOS asks nothing of the kind.
 
 You install it. You go through a setup that feels like Apple's. You talk to it.
 It answers. It runs your workflows. It lives in your dashboard. It picks up your voice.
-It messages you on WhatsApp when a task finishes.
 
 That is the promise: AI that belongs to you, fully, without compromise.
 
@@ -29,8 +28,7 @@ That is the promise: AI that belongs to you, fully, without compromise.
 - **Bootable or installable** — ships as a clean Ubuntu-based ISO or installs onto an existing machine.
 - **Local-first and offline-capable** — Ollama models on your hardware. No cloud required, no API keys.
 - **Command Center** — a polished dashboard at :7070. Operations, workflows, traces, approvals, settings.
-- **Voice** — Whisper STT + Piper TTS. Wake word. Push-to-talk. Native audio pipeline.
-- **WhatsApp** — scan once. Message JARVIS from your phone. Approve tool calls by replying.
+- **Voice** — Whisper STT + Piper TTS. Wake word ("Hey Claw"). Push-to-talk. Native audio pipeline.
 - **Workflows** — 29 prebuilt jobs across files, documents, code, content, system, and data. One click.
 - **Packs** — curated use-case configurations. Pick "Coding Autopilot" or "Daily Briefing OS" during setup.
 - **Provider-neutral** — local Ollama by default. Plug in Anthropic, OpenAI, or any compatible endpoint.
@@ -75,7 +73,7 @@ ISO validation target: Tier A + B on clean Ubuntu.
 ## Runtime Ecosystem
 
 ### Claw Core / Nexus (default)
-Native Python ReAct agent. Works on 8GB RAM. CPU-only capable.
+Native Python agent with native Ollama function calling. Works on 8GB RAM. CPU-only capable.
 The reliable foundation every user gets by default.
 
 ### PicoClaw (Tier A ARM)
@@ -112,7 +110,7 @@ This is not a metaphor for style. It is a quality filter.
 **JARVIS standard:**
 - It anticipates. Workflows surface when the agent detects relevant context.
 - It explains itself. Traces and approvals make the AI's actions transparent.
-- It works across surfaces. Voice, dashboard, WhatsApp, CLI — same intelligence.
+- It works across surfaces. Voice, dashboard, CLI — same intelligence.
 - It never loses context. Memory is durable, layered, and searchable.
 - It stays in the background until you need it.
 

--- a/docs/PROJECT_TRUTH.md
+++ b/docs/PROJECT_TRUTH.md
@@ -1,13 +1,19 @@
 # ClawOS — Project Truth
 ## Version 0.1.0 Prototype | March 2026
 
+> **Historical document.** This was written in March 2026 during initial design.
+> The file tree and session plan below reflect the original intended structure, not the
+> current codebase. For current canonical architecture see `docs/ARCHITECTURE_CURRENT.md`.
+> WhatsApp/gatewayd was planned here but was never shipped — those paths do not exist.
+> Model defaults have changed: Tier A uses qwen2.5:3b, not gemma3:4b (fixed in v0.1.1).
+
 ---
 
 ## One sentence definition
 
 ClawOS is a preconfigured, low-RAM, local-first agent OS that boots into a
 working AI environment — with policy-gated tools, workspace isolation, memory,
-voice, WhatsApp, and optional OpenClaw — on consumer hardware, offline, free.
+voice, and optional OpenClaw — on consumer hardware, offline, free.
 
 ---
 
@@ -19,7 +25,6 @@ voice, WhatsApp, and optional OpenClaw — on consumer hardware, offline, free.
 - Local-first: all data on device, no cloud, no API keys
 - Safe: every tool call gated through policyd
 - Voice: Whisper STT + Piper TTS, offline
-- WhatsApp: message Jarvis from your phone, approve tool calls by replying
 - Dashboard: operations console at :7070
 - One-command startup, first-run wizard, opinionated defaults
 
@@ -36,12 +41,11 @@ voice, WhatsApp, and optional OpenClaw — on consumer hardware, offline, free.
 ## Two runtimes
 
 ### Claw Core (default)
-- Our native Python ReAct agent
-- Works on 8GB RAM, gemma3:4b, CPU-only
-- 56/56 tests passing
+- Our native Python agent with native Ollama function calling
+- Works on 8GB RAM, qwen2.5:3b, CPU-only
+- 61/61 tests passing
 - 4-layer memory (PINNED + WORKFLOW + ChromaDB + FTS5 + HISTORY)
 - Merkle audit trail, lifecycle hooks, asyncio.Event per call
-- WhatsApp via our gatewayd
 - Voice via voiced
 
 ### OpenClaw (optional, installed on request)
@@ -49,9 +53,8 @@ voice, WhatsApp, and optional OpenClaw — on consumer hardware, offline, free.
 - Pre-configured for Ollama offline (no API keys, no cloud)
 - Pre-patched with known Linux fixes (auth-profiles bug, etc.)
 - Config: openclaw.json points at localhost:11434, api: openai-completions
-- Needs qwen2.5:7b or better (not gemma3:4b — needs tool calling support)
-- User scans WhatsApp QR once, then it just works
-- Installed via: clawctl openclaw install
+- Needs qwen2.5:7b or better (needs tool calling support)
+- Installed via: clawctl openclaw install (or: ollama launch openclaw)
 - Started via: clawctl openclaw start
 
 ### Runtime selection
@@ -79,15 +82,14 @@ Primary dev hardware: ROG Ally RC71L (Tier B, balanced profile)
 ## Canonical internal flow (Claw Core)
 
 ```
-User input (CLI / WhatsApp / Voice / Dashboard)
-  → gatewayd (route to workspace)
+User input (CLI / Voice / Dashboard)
   → agentd (task queue)
   → context_builder (SOUL + AGENTS + memory recall)
   → modeld (Ollama inference)
   → tool request
   → policyd (ALLOW / DENY / QUEUE)
   → toolbridge (execute)
-  → event bus (broadcast to dashboard + WhatsApp)
+  → event bus (broadcast to dashboard)
   → response synthesis
   → output (same channel as input)
 ```
@@ -104,7 +106,6 @@ User input (CLI / WhatsApp / Voice / Dashboard)
 6. voiced   (optional)
 7. clawd    — orchestration, hardware detection, scheduler
 8. dashd    — observes everything
-9. gatewayd — WhatsApp bridge (optional, after clawd)
 
 ---
 

--- a/docs/SUPABASE_SETUP.md
+++ b/docs/SUPABASE_SETUP.md
@@ -1,7 +1,16 @@
-# ClawOS — Supabase Setup (dummy-proof)
+# ClawOS — Supabase Setup (draft — not shipped)
 
-This guide sets up the Supabase database that ClawOS uses for license validation.  
-No programming knowledge needed. Takes about 5 minutes.
+> **Note:** ClawOS has no paid tier and ships no license validation system.
+> This document is a draft that was never integrated into the product.
+> It is kept for reference only. Do not implement or ship any of this.
+> The product commitment is: AGPL-3.0, no paid tier, no telemetry, forever.
+
+---
+
+This guide describes how a Supabase-backed license system *would* work,
+retained only as a reference in case the project ever needs it.
+
+---
 
 ---
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -9,7 +9,7 @@ Complete testing procedures for ClawOS development and deployment.
 Run all tests in one command:
 
 ```bash
-cd /home/jarvis/clawos-analysis
+cd ~/clawos
 
 # Run comprehensive test suite
 python3 -c "

--- a/packaging/launch/demo_script.md
+++ b/packaging/launch/demo_script.md
@@ -5,31 +5,31 @@
 
 ## What to record
 
-### Shot 1 — The flash (10 seconds)
+### Shot 1 — The install (10 seconds)
 Show terminal:
 ```
-sudo dd if=clawos-0.1.0-amd64.iso of=/dev/sdb bs=4M status=progress oflag=sync
+curl -fsSL https://install.clawos.io | bash
 ```
-Let the progress bar run for a few seconds. Cut.
+Let the progress scroll for a few seconds. Cut.
 
 ### Shot 2 — The boot (15 seconds)
-Show BIOS boot screen → ClawOS MOTD appearing in terminal.
-The MOTD with the ASCII art logo is the visual hook.
+Show dashboard opening at http://localhost:7070 — dark theme, Overview page.
+The command center appearing is the visual hook.
 Let it sit for 2 seconds.
 
-### Shot 3 — First chat (20 seconds)
+### Shot 3 — Morning briefing (20 seconds)
 ```
-clawctl chat
+clawctl demos morning-briefing
 ```
-Type: `summarise the files in my workspace`
-Show Jarvis responding.
-Type: `remember that i prefer dark mode`
-Show: `[MEMORY] Saved`
+Show the spoken briefing playing through Piper TTS.
+Show the five parallel tool calls in the terminal output.
 
-### Shot 4 — WhatsApp (15 seconds)
-Show phone — message sent to Jarvis number.
-Cut to terminal showing incoming message.
-Cut back to phone — Jarvis reply appearing.
+### Shot 4 — Approval popup (15 seconds)
+```
+clawctl demos approval-test
+```
+Show the floating borderless Tauri window appearing over the desktop.
+Click Approve. Show confirmation.
 
 ---
 
@@ -55,10 +55,10 @@ ffmpeg -i demo.mp4 -vf "fps=12,scale=800:-1:flags=lanczos" \
 
 ## Caption for social
 
-> Flash a USB. Boot. Your AI is ready.
+> One command. No cloud. Your AI is ready.
 >
-> ClawOS — OpenClaw + Ollama on any machine.
-> No API keys. No setup. No monthly bill.
+> ClawOS — local AI agent on your Linux machine.
+> No API keys. No setup complexity. No monthly bill.
 >
-> github.com/you/clawos
-> #ai #selfhosted #homelab #openclaw #ollama
+> github.com/xbrxr03/clawos
+> #ai #selfhosted #homelab #ollama #localai

--- a/packaging/launch/hn_post.md
+++ b/packaging/launch/hn_post.md
@@ -1,12 +1,12 @@
 # Hacker News Launch Post
 
 ## Title (pick one)
-- "ClawOS – bootable ISO that runs OpenClaw + Ollama locally, no API keys"
+- "Show HN: ClawOS – local-first AI agent that runs on your existing Linux laptop"
 - "Show HN: ClawOS – flash a USB, boot, your AI agent is running offline"
 - "ClawOS – the first OS built specifically for local AI agents"
 
 ## Best title
-**Show HN: ClawOS – bootable ISO that runs OpenClaw + Ollama offline, no API keys**
+**Show HN: ClawOS – local-first AI agent for your laptop, no cloud, no API keys**
 
 ---
 
@@ -14,47 +14,38 @@
 
 Hi HN,
 
-I built ClawOS — a bootable Linux ISO that turns any x86 machine into a local AI agent computer.
+I built ClawOS — a local AI agent that installs on your existing Linux machine (or boots from ISO) and runs entirely offline.
 
-Flash the ISO, boot from USB, and you have OpenClaw running offline in about 2 minutes.
-No npm. No pip. No config. No API keys. No monthly bill.
+One command to install:
+
+```bash
+curl -fsSL https://install.clawos.io | bash
+```
+
+Or flash the ISO and boot from USB:
 
 ```
-sudo dd if=clawos-0.1.0-amd64.iso of=/dev/sdX bs=4M status=progress
+sudo dd if=clawos-0.1.1-amd64.iso of=/dev/sdX bs=4M status=progress
 ```
 
-**Why I built it:**
+**What it does:**
 
-OpenClaw costs $300-750/month in API tokens. There's an active CVE (CVE-2026-25253)
-that lets anyone steal your keys in one click. The original creator just left for OpenAI.
-Meanwhile the software itself is brilliant — 13,700+ community skills, WhatsApp,
-Telegram, voice, agent-to-agent communication.
+- Say "Hey Claw" → get a spoken morning briefing (time, weather, calendar, tasks). Five tool calls, parallel, Piper TTS.
+- "Write 1000 words on AI ethics and paste it into the text editor" → 4 tool chain, essay lands in gedit.
+- Sensitive operations (file delete, shell commands) show a floating native approval popup — not a browser tab.
+- Everything runs via Ollama. Works offline.
 
-I wanted all of that but offline, on hardware I own, for free.
+**Hardware:**
 
-**What's different:**
-
-Every other alternative is software you install on top of an existing OS.
-ClawOS is the OS. It comes with:
-- OpenClaw pre-configured for Ollama (no API keys ever)
-- gemma3:4b pulled on first boot
-- Pre-applied Linux auth fix (the bug that breaks Ollama+OpenClaw on Linux)
-- Claw Core — a lightweight native Python agent for low-RAM machines (8GB)
-- Full security layer (policyd, Merkle audit trail, human approval queue)
-- Dashboard at :7070
-
-Works on: ROG Ally, Intel NUC, old laptops, mini PCs, anything x86_64 with 8GB+.
-
-**Hardware note:**
-
-8GB = Claw Core only (gemma3:4b)
-16GB = + OpenClaw with qwen2.5:7b
+8GB = Claw Core only (qwen2.5:3b, fast CPU inference)
+16GB = full stack + OpenClaw optional (qwen2.5:7b)
 32GB+ = larger models, faster inference
 
-**GitHub:** https://github.com/you/clawos
+**Architecture:** 10 microservices, FastAPI, SQLite, Tauri overlay, systemd user units. AGPL-3.0.
 
-Happy to answer questions about the architecture, the OpenClaw offline setup,
-or the ISO build process.
+**GitHub:** https://github.com/xbrxr03/clawos
+
+Happy to answer questions about the architecture, the offline Ollama setup, or the Tauri approval overlay.
 
 ---
 
@@ -63,17 +54,6 @@ or the ISO build process.
 - r/selfhosted  — this is their exact audience
 - r/homelab     — "AI appliance on a mini PC" framing
 - r/LocalLLaMA  — technical audience, will care about offline + no API keys
-- r/OpenClaw (if exists) — direct audience
-
-## Journalists who covered OpenClaw scandals
-
-Search for recent coverage of:
-- CVE-2026-25253
-- OpenClaw "lethal trifecta" (Palo Alto Networks)
-- Cisco "17% of ClawHub skills malicious"
-- OpenClaw creator leaving for OpenAI
-
-Those journalists are primed for "here's the safe local alternative" story.
 
 ## Timing
 

--- a/scripts/install-resume.sh
+++ b/scripts/install-resume.sh
@@ -20,7 +20,8 @@ echo ""
 if [ ! -d "$INSTALL_DIR" ]; then
     echo -e "  ${R}No existing installation found at $INSTALL_DIR${RESET}"
     echo "  Run the full installer first:"
-    echo "  curl -fsSL https://raw.githubusercontent.com/xbrxr03/clawos/main/install.sh | bash"
+    echo "  curl -fsSL https://raw.githubusercontent.com/xbrxr03/clawos/main/install.sh \\"
+    echo "      | bash"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Swept all 50 .md files in the repo. One commit touching 15 files across 7 categories of issues:

- **WhatsApp removed** — feature was never shipped; removed from AGENTS.md, HEARTBEAT.md, IDENTITY.md, SOUL.md, ARCHITECTURE_CURRENT.md, PRODUCT_VISION.md, PROJECT_TRUTH.md
- **Wake word standardised** — `demos/README.md`: "Hey JARVIS" → "Hey Claw"
- **Model defaults corrected** — PROJECT_TRUTH.md: Tier A `qwen2.5:3b`, not `gemma3:4b`; Nexus described as native Ollama function calling, not ReAct
- **Fabricated claims removed** — `packaging/launch/hn_post.md` rewritten: CVE-2026-25253, "creator left for OpenAI", "Cisco 17% malicious" all removed; placeholder URLs fixed
- **Demo script updated** — Shot 4 WhatsApp → approval popup; install command corrected; social URL fixed
- **Wrong repo URL** — `docs/DEPLOYMENT_GUIDE.md`: `openclaw/clawos` → `xbrxr03/clawos`
- **Dev machine path removed** — `docs/TESTING_GUIDE.md`: `/home/jarvis/clawos-analysis` → `~/clawos`
- **Licensing contradiction clarified** — `docs/SUPABASE_SETUP.md`: prominent note that this draft does not ship; AGPL, no paid tier, forever
- **Version numbers updated** — API_REFERENCE.md and FEATURES.md bumped to 0.1.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPcoiRqJitanpcw3DdGuH7)_