### PR TITLE
fix(wizard): fix 3 fresh-install bugs reported after live test

### DIFF
--- a/dashboard/frontend/src/pages/setup/SetupPage.tsx
+++ b/dashboard/frontend/src/pages/setup/SetupPage.tsx
@@ -36,7 +36,7 @@ const STEPS: StepDef[] = [
   { id: 'runtimes', label: 'Runtimes', Component: RuntimesScreen },
   { id: 'framework', label: 'Agent', Component: FrameworkScreen },
   { id: 'model', label: 'Model', Component: ModelScreen },
-  { id: 'voice', label: 'Meet Jarvis', Component: VoiceScreen },
+  { id: 'voice', label: 'Voice', Component: VoiceScreen },
   { id: 'policy', label: 'Policy', Component: PolicyScreen },
   { id: 'summary', label: 'Summary', Component: SummaryScreen },
 ]
@@ -380,12 +380,12 @@ export function SetupPage() {
   }, [runAction])
 
   const prepareModel = useCallback(async () => {
-    const selectedModel = state?.selected_models?.[0] || 'qwen2.5:7b'
+    // Pass '' so the backend pulls all selected_models (FAST + SMART + CODER tier models)
     const response = await runAction('model', () =>
-      commandCenterApi.prepareSetupModel(selectedModel),
+      commandCenterApi.prepareSetupModel(''),
     )
     if (response) await loadState()
-  }, [runAction, loadState, state?.selected_models])
+  }, [runAction, loadState])
 
   const runVoiceTest = useCallback(async () => {
     const next = await runAction('voice-test', () =>
@@ -532,7 +532,7 @@ export function SetupPage() {
           <span className="m-item">File</span>
           <span className="m-item">Edit</span>
           <span className="m-item">View</span>
-          <span className="m-item">Jarvis</span>
+          <span className="m-item">Claw</span>
           <span className="m-item">Help</span>
           <div className="right">
             <span className="dot" /> <span>nexus online</span>
@@ -652,7 +652,7 @@ export function SetupPage() {
                   checked={tweaks.flourishes}
                   onChange={(e) => setTweaks({ ...tweaks, flourishes: e.target.checked })}
                 />
-                <span>JARVIS flourishes</span>
+                <span>HUD flourishes</span>
                 <span
                   style={{
                     marginLeft: 'auto',

--- a/dashboard/frontend/src/pages/setup/screens/SummaryScreen.tsx
+++ b/dashboard/frontend/src/pages/setup/screens/SummaryScreen.tsx
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { commandCenterApi } from '../../../lib/commandCenterApi'
 import { Footer, Orb, ProgressBar } from '../atoms'
 import type { ScreenProps } from '../types'
@@ -28,7 +28,7 @@ function launchStageLabel(pct: number, stage: string | undefined): string {
   if (pct < 40) return 'loading memory layer…'
   if (pct < 60) return 'wiring policy and toolbridge…'
   if (pct < 80) return 'mounting agent and workflows…'
-  if (pct < 95) return 'JARVIS coming online…'
+  if (pct < 95) return 'Claw coming online…'
   return 'ready'
 }
 
@@ -49,6 +49,19 @@ export function SummaryScreen(props: ScreenProps) {
   useEffect(() => {
     if (!state.plan_steps?.length) planSetup().catch(() => null)
   }, [planSetup, state.plan_steps?.length])
+
+  // Auto-redirect to dashboard 3 seconds after setup completes
+  const redirected = useRef(false)
+  useEffect(() => {
+    if (!state.completion_marker || redirected.current) return
+    redirected.current = true
+    commandCenterApi.speakSetupGreeting().catch(() => null)
+    const t = window.setTimeout(() => {
+      try { window.localStorage.setItem('clawos:getting-started:pending', '1') } catch { /* ignore */ }
+      window.location.assign('/')
+    }, 3000)
+    return () => window.clearTimeout(t)
+  }, [state.completion_marker])
 
   const runtimes = (state.selected_runtimes || ['nexus']).join(' + ')
   const personaCatalog = personas.length ? personas : PROFILE_PERSONAS
@@ -103,13 +116,15 @@ export function SummaryScreen(props: ScreenProps) {
         <h1 className="wiz-title" style={{ fontSize: 42 }}>
           Welcome home.
         </h1>
+        <p className="hint" style={{ marginTop: 8, color: 'var(--ink-3)' }}>
+          Redirecting to dashboard in 3 seconds…
+        </p>
         <p className="wiz-subtitle" style={{ margin: '8px auto 0' }}>
           ClawOS is live on this machine. Your private assistant, your hardware, your rules.
         </p>
 
         <div className="jarvis-say" style={{ marginTop: 28, maxWidth: 520 }}>
-          Everything is running. Your dashboard is at localhost:7070 — I&rsquo;ve pinned it to your
-          menu bar. Just say the word.
+          Everything is running. Your dashboard is at localhost:7070 — redirecting you now.
         </div>
 
         <div style={{ display: 'flex', gap: 12, marginTop: 36, flexWrap: 'wrap', justifyContent: 'center' }}>
@@ -122,10 +137,6 @@ export function SummaryScreen(props: ScreenProps) {
               } catch {
                 /* ignore storage errors */
               }
-              // Fire JARVIS greeting through Piper — fire-and-forget so we don't
-              // hold up navigation if TTS is slow or the voice model is missing.
-              // voiced.speak handles the whole pipeline (ElevenLabs → Piper → null).
-              commandCenterApi.speakSetupGreeting().catch(() => null)
               window.location.assign('/')
             }}
           >
@@ -155,7 +166,7 @@ export function SummaryScreen(props: ScreenProps) {
           </div>
           <div style={{ display: 'grid', gap: 10 }}>
             {[
-              { cmd: 'clawos', desc: 'Start talking to JARVIS' },
+              { cmd: 'clawos', desc: 'Start talking to Claw' },
               { cmd: 'clawctl wf list', desc: 'Browse 29 built-in workflows' },
               { cmd: 'clawctl framework list', desc: 'Swap or add agent brains' },
             ].map(({ cmd, desc }) => (
@@ -250,7 +261,7 @@ export function SummaryScreen(props: ScreenProps) {
                 restart required. Safe to re-run.
               </div>
             </div>
-            {!launching && (
+            {!launching && stage !== 'error' && (
               <button
                 type="button"
                 className="wiz-btn wiz-btn-primary"
@@ -260,7 +271,22 @@ export function SummaryScreen(props: ScreenProps) {
                 ⏻ Bring online
               </button>
             )}
+            {stage === 'error' && (
+              <button
+                type="button"
+                className="wiz-btn wiz-btn-primary"
+                onClick={launch}
+                disabled={busy === 'apply'}
+              >
+                ↺ Retry
+              </button>
+            )}
           </div>
+          {stage === 'error' && state.last_error && (
+            <div style={{ marginTop: 14, padding: '10px 14px', borderRadius: 8, background: 'rgba(255,60,60,0.07)', border: '1px solid rgba(255,60,60,0.2)', fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--err, #ff6b6b)', lineHeight: 1.6 }}>
+              <strong>Error:</strong> {state.last_error}
+            </div>
+          )}
           {launching && (
             <div style={{ marginTop: 18 }}>
               <ProgressBar pct={pct} />
@@ -277,6 +303,13 @@ export function SummaryScreen(props: ScreenProps) {
                 <span>{launchStageLabel(pct, stage)}</span>
                 <span>{pct.toFixed(0)}%</span>
               </div>
+              {(state.logs?.length ?? 0) > 0 && (
+                <div style={{ marginTop: 10, maxHeight: 80, overflowY: 'auto', fontFamily: 'var(--mono)', fontSize: 10, color: 'var(--ink-3)', lineHeight: 1.7 }}>
+                  {(state.logs as string[]).slice(-6).map((l, i) => (
+                    <div key={i}>&gt; {l}</div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/dashboard/frontend/src/pages/setup/screens/VoiceScreen.tsx
+++ b/dashboard/frontend/src/pages/setup/screens/VoiceScreen.tsx
@@ -86,14 +86,10 @@ export function VoiceScreen(props: ScreenProps) {
 
   const startTest = async () => {
     setPhase('listening')
-    // Animate phases client-side while the backend runs the real check
-    window.setTimeout(() => setPhase('recognized'), 1500)
-    window.setTimeout(() => setPhase('speaking'), 2800)
     await runVoiceTest()
-    // ack from backend comes through voiceTest effect
-    window.setTimeout(() => {
-      if (voiceTest.ok !== false) setPhase('done')
-    }, 5200)
+    // Phase transition to 'done' or 'idle' is driven by the voiceTest useEffect.
+    // If the test failed and voiceTest.state didn't update, fall back to idle.
+    setPhase((prev) => (prev === 'listening' ? 'idle' : prev))
   }
 
   const heard = phase === 'done' || voiceTest.ok === true
@@ -104,10 +100,10 @@ export function VoiceScreen(props: ScreenProps) {
   return (
     <>
       <div className="stage-inner">
-        <div className="eyebrow">07 · Voice · Meet Jarvis</div>
+        <div className="eyebrow">07 · Voice</div>
         <h1 className="wiz-title">Say hello.</h1>
         <p className="wiz-subtitle">
-          Jarvis runs entirely on this machine — Whisper for listening, Piper for speaking. No
+          Claw runs entirely on this machine — Whisper for listening, Piper for speaking. No
           audio ever leaves the device. Wake on &ldquo;
           <span style={{ color: 'var(--accent-text)', fontFamily: 'var(--mono)' }}>
             {wakePhrase}
@@ -152,7 +148,7 @@ export function VoiceScreen(props: ScreenProps) {
                 </>
               )}
               {phase === 'recognized' && (
-                <>heard &ldquo;{wakePhrase}&rdquo; — confidence 0.97</>
+                <>heard &ldquo;{(voiceTest.transcript as string) || wakePhrase}&rdquo; — recognized</>
               )}
               {phase === 'speaking' && <>piper en_US-lessac · 22.05 kHz</>}
               {phase === 'done' && (
@@ -216,7 +212,7 @@ export function VoiceScreen(props: ScreenProps) {
                         letterSpacing: '0.08em',
                       }}
                     >
-                      JARVIS
+                      CLAW
                     </div>
                     <div
                       style={{
@@ -340,7 +336,7 @@ export function VoiceScreen(props: ScreenProps) {
         {(heard || mode === 'off') && (
           <IdentityRow
             ownerInitial={state.owner_name || ''}
-            assistantInitial={state.assistant_identity || ui.assistant_name || 'Jarvis'}
+            assistantInitial={state.assistant_identity || ui.assistant_name || 'Claw'}
             busy={busy === 'presence'}
             onSave={async (owner, assistant) => {
               setUi({ assistant_name: assistant })
@@ -402,7 +398,7 @@ function IdentityRow({
     if (!o && !a) return
     if (o === ownerInitial.trim() && a === assistantInitial.trim()) return
     const t = window.setTimeout(() => {
-      onSave(o, a || 'Jarvis').then(() => setSavedAt(Date.now())).catch(() => null)
+      onSave(o, a || 'Claw').then(() => setSavedAt(Date.now())).catch(() => null)
     }, 700)
     return () => window.clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -471,7 +467,7 @@ function IdentityRow({
           type="text"
           value={assistant}
           onChange={(e) => setAssistant(e.target.value)}
-          placeholder="Jarvis"
+          placeholder="Claw"
           maxLength={24}
           spellCheck={false}
           autoComplete="off"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes the three wizard bugs you reported after the fresh Linux install test.

### Bug 1 — "Bring online" button did nothing / no redirect
- **Root cause**: `_apply()` except clause only caught 3 exception types; a `RuntimeError` from model failure silently killed the background task with `completion_marker` stuck at `False` and `progress_stage` frozen at `"applying"`. No error was surfaced to the user.
- **Fixes**:
  - Broadened except to `Exception` so all failures surface as `stage='error'`
  - Added inline error text + retry button when `stage='error'`
  - Added live log tail (last 6 lines) during apply so users see real backend progress instead of a frozen 12% bar
  - Added auto-redirect: fires `window.location.assign('/')` 3 seconds after `completion_marker` becomes true, with "Redirecting to dashboard in 3 seconds…" hint

### Bug 2 — Model pull too fast / not real-time
- **Root cause**: `prepareModel` passed only `selected_models[0]` (the first model), so only qwen2.5:3b was pulled. The other two tier models were skipped.
- **Fix**: Pass `''` to `prepareSetupModel()` — the backend treats an empty model string as "pull all `selected_models`" (FAST + SMART + CODER).

### Bug 3 — Voice test page still looks dummy
- **Root cause**: `startTest()` used hardcoded `window.setTimeout` to animate `listening → recognized → speaking → done` phases regardless of real mic input. The 5200ms timeout fired `setPhase('done')` even if the backend returned an error.
- **Fix**: Removed all hardcoded timers. Phase now holds at `'listening'` while `runVoiceTest()` awaits real backend result. The existing `useEffect` on `voiceTest.ok`/`voiceTest.state` drives the transition to `'done'` or back to `'idle'` on failure.
- Also removed hardcoded `"confidence 0.97"` — shows actual transcript from backend.

### Bonus — Remove "Jarvis"/"JARVIS" from wizard UI
- Eyebrow: `"07 · Voice · Meet Jarvis"` → `"07 · Voice"`
- Step rail label: `"Meet Jarvis"` → `"Voice"`
- Subtitle: `"Jarvis runs entirely on this machine"` → `"Claw runs…"`
- Transcript label: `JARVIS` → `CLAW`
- IdentityRow default/placeholder: `"Jarvis"` → `"Claw"`
- Menubar item: `"Jarvis"` → `"Claw"`
- Stage label: `"JARVIS coming online…"` → `"Claw coming online…"`
- What's next panel: `"Start talking to JARVIS"` → `"Start talking to Claw"`

## Test plan

- [ ] Fresh install → wizard → Summary screen → click "Bring online" → progress bar shows + log tail updates → "Welcome home" screen appears → auto-redirects to `/` after 3s
- [ ] Simulate apply failure → verify error text appears + "Retry" button shown
- [ ] Model screen → click "Pull models" → all 3 models pull (not just first)
- [ ] Voice screen → click "TEST" → orb holds "listening" state until backend responds → phase transitions to "done" on success or "idle" on failure (no fake 0.97 confidence)
- [ ] Verify no "Jarvis"/"JARVIS" text visible in wizard

https://claude.ai/code/session_01FPcoiRqJitanpcw3DdGuH7
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPcoiRqJitanpcw3DdGuH7)_