### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,127 +1,200 @@
 # Contributing to ClawOS
 
-Thanks for your interest. ClawOS is a local-first AI agent stack — every
-contribution should preserve that promise (no cloud, no API keys, no
-telemetry, runs offline).
+Thanks for your interest in contributing! ClawOS is a local-first AI agent OS — every contribution makes local AI better for everyone.
+
+## Quick Links
+
+- [Good First Issues](https://github.com/xbrxr03/clawos/labels/good%20first%20issue) — beginner-friendly tasks
+- [Discussions](https://github.com/xbrxr03/clawos/discussions) — questions, ideas, RFCs
+- [Roadmap](docs/ROADMAP.md) — where the project is headed
 
 ---
 
-## Quick start
+## Development Setup
+
+### Prerequisites
+
+- **Python 3.10+** (specified in `pyproject.toml`)
+- **[Ollama](https://ollama.com)** with at least `qwen2.5:3b` pulled (for running the agent)
+- **Git**
+
+### Install
 
 ```bash
-git clone https://github.com/xbrxr03/clawos.git
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/clawos.git
 cd clawos
+
+# Create a virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# Install with dev dependencies
 pip install -e ".[dev]"
-
-# Run the agent unit tests (fast, no live LLM)
-pytest tests/unit/test_agent_*.py -q
 ```
 
----
+### Optional Dependencies
 
-## How to contribute
-
-### Bug fixes
-- Open an issue first if it's non-trivial — saves time
-- Branch from `main`, name like `fix/<short-description>`
-- Add a regression test where it makes sense
-- Open a PR with the fix + test
-
-### Features
-- Open an issue describing the feature first
-- Wait for a maintainer to mark it `accepted` before writing code
-- Branch like `feat/<short-description>`
-- Keep PRs small — split large features into multiple PRs
-
-### Docs
-- README, `docs/`, code comments — all welcome
-- Run `grep -i "todo\|fixme"` over your changes, clean them up before
-  PR
-
----
-
-## Code style
-
-- **Python:** stdlib + already-pinned dependencies. Don't add heavy deps
-  without strong justification.
-- **TypeScript / React:** match the surrounding file's style. No
-  Tailwind, no shadcn — we use a custom design system in
-  `dashboard/frontend/src/`.
-- **Comments:** WHY only, never WHAT. The code already explains what.
-- **New files:** SPDX-License-Identifier header at top, docstring
-  explaining the module's role.
-- **Type hints:** encouraged but not enforced. Match the surrounding
-  file.
-
-### Where things live
-
-| What | Where |
-|------|-------|
-| New agent tools | `runtimes/agent/tools/{category}.py` |
-| Tool schemas | `runtimes/agent/tool_schemas.py` |
-| New daemons | `services/{name}d/` |
-| Dashboard pages | `dashboard/frontend/src/pages/{Page}.tsx` |
-| Setup wizard screens | `dashboard/frontend/src/pages/setup/screens/` |
-| Tests | `tests/unit/test_{module}.py` |
-
----
-
-## Commit messages
-
-Match the existing style:
-
-```
-type(scope): brief description
-
-Longer explanation if needed. WHY this change, not WHAT.
-
-Co-Authored-By: ... (if pairing)
-```
-
-Examples:
-- `fix(install): handle missing python3 on Debian 12`
-- `feat(reminderd): notification daemon for due reminders`
-- `refactor(toolbridge): consolidate shell allowlist into single module`
-
----
-
-## What we won't accept
-
-- **Telemetry of any kind.** Zero. Forever. This is a hard line.
-- **Cloud-dependent features** that can't be disabled or run offline
-- **Closed-source dependencies** (commercial libraries with restrictive licenses)
-- **Anything that breaks the offline-first promise** without an
-  explicit user opt-in
-- **AI-slop PRs** — code that obviously wasn't read, tests that don't
-  test anything, comments narrating each line
-
----
-
-## Testing
+Install extras based on what you're working on:
 
 ```bash
-# Agent loop unit tests (fast, runs in <2s)
-pytest tests/unit/test_agent_*.py -q
-
-# Full unit suite
-pytest tests/unit -q
-
-# Integration (slower, exercises live services)
-pytest tests/integration -q
+pip install -e ".[voice]"     # STT/TTS (Whisper, Piper)
+pip install -e ".[memory]"    # ChromaDB, json-repair
+pip install -e ".[browser]"   # Playwright
+pip install -e ".[brain]"     # LangChain experimental
+pip install -e ".[full]"      # Everything
 ```
 
-Don't write tests that hit live LLMs — mock them or skip.
+### Verify Installation
+
+```bash
+clawctl health    # Check that all services are running
+```
+
+---
+
+## Running Tests
+
+```bash
+# Run all unit tests (no live LLM required)
+pytest tests/ -v --tb=short
+
+# Run a specific test file
+pytest tests/unit/test_agent_loop.py -v
+
+# Run with coverage
+pytest tests/ --cov=clawos_core --cov=services --cov=skills --cov-report=html
+
+# Quick tests only (skip slow marks)
+pytest tests/ -v -m "not slow"
+```
+
+Tests live in `tests/unit/`, `tests/integration/`, `tests/system/`, and `tests/services/`. Unit tests don't require a running Ollama instance.
+
+---
+
+## Code Style
+
+We use **[Ruff](https://docs.astral.sh/ruff/)** for linting and formatting, configured in `pyproject.toml`:
+
+- **Line length:** 100 characters
+- **Target Python:** 3.10+
+- **Formatter:** Ruff (replaces Black + isort)
+
+Run checks before committing:
+
+```bash
+# Lint
+ruff check .
+
+# Format
+ruff format .
+```
+
+Or use the Makefile:
+
+```bash
+make lint      # flake8 + pylint
+make format    # black + isort (line-length=100)
+make format-check
+```
+
+### Conventions
+
+- Follow existing patterns in the codebase
+- Keep functions small and focused
+- Use type hints for public APIs
+- Add docstrings to modules and public functions
+- **Document *why*, not *what*** — code shows what, comments show why
+
+---
+
+## Pull Request Process
+
+1. **Fork** the repository
+2. **Create a branch** from `main`:
+   ```bash
+   git checkout -b feature/my-feature
+   # or
+   git checkout -b fix/issue-42
+   ```
+3. **Make your changes** — keep commits focused and atomic
+4. **Write/update tests** — especially for bug fixes and new features
+5. **Run the test suite** — make sure everything passes:
+   ```bash
+   pytest tests/ -v --tb=short
+   ```
+6. **Commit with conventional messages:**
+   ```
+   feat: add voice command for setting timers
+   fix: prevent list mutation in agent tool parsing
+   docs: update API reference for memd endpoints
+   refactor: extract approval popup into reusable component
+   test: add unit tests for memory layer
+   chore: update dependencies
+   ```
+7. **Push** to your fork and open a PR against `main`
+8. **Respond to review feedback** — we'll work with you to get it merged
+
+### PR Checklist
+
+- [ ] Tests pass locally (`pytest tests/`)
+- [ ] New code has tests
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No unrelated changes in the PR
+- [ ] Documentation updated if needed
+
+---
+
+## Reporting Bugs
+
+Use the [Bug Report](https://github.com/xbrxr03/clawos/issues/new?template=bug_report.md) template. Include:
+
+- ClawOS version (`clawctl --version`)
+- OS and hardware (especially RAM and GPU)
+- Steps to reproduce
+- Expected vs. actual behavior
+- Logs if available (`clawctl logs <service>`)
+
+---
+
+## Suggesting Features
+
+Use the [Feature Request](https://github.com/xbrxr03/clawos/issues/new?template=feature_request.md) template. Describe the use case, not just the solution.
+
+---
+
+## Project Structure
+
+```
+clawos/
+├── clawos_core/          # Core library
+├── runtimes/agent/       # Nexus agent loop (4-tier pipeline)
+│   ├── runtime.py        #   Priority pipeline: memory → confirm → intent → LLM
+│   ├── intents.py        #   Deterministic regex classifier
+│   ├── router.py         #   3b/7b/coder dynamic model router
+│   ├── tool_schemas.py   #   31 tool JSON schemas for Ollama function calling
+│   └── tools/            #   Tool modules (Linux + macOS)
+├── services/             # 29 daemons (FastAPI + SQLite)
+├── workflows/            # 28 built-in workflows
+├── desktop/command-center/ # Tauri shell + approval overlay
+├── dashboard/frontend/   # React SPA
+├── clawctl/              # CLI
+├── tests/                # Unit + integration + system tests
+├── docs/                 # Documentation
+└── packaging/            # AppImage, .deb, AUR, ISO
+```
+
+---
+
+## Getting Help
+
+- **Questions?** [GitHub Discussions](https://github.com/xbrxr03/clawos/discussions)
+- **Bugs?** [Open an issue](https://github.com/xbrxr03/clawos/issues)
+- **Security?** See [SECURITY_AUDIT.md](docs/SECURITY_AUDIT.md)
 
 ---
 
 ## License
 
-ClawOS is [AGPL-3.0](LICENSE). By contributing, you agree your code
-is licensed under the same terms.
-
----
-
-## Community
-
-- 🐛 [Issues](https://github.com/xbrxr03/clawos/issues) for bugs
-- 💬 GitHub Discussions for questions and ideas
+By contributing, you agree that your contributions will be licensed under [AGPL-3.0](LICENSE).


### PR DESCRIPTION
## What

Comprehensive CONTRIBUTING.md replacing the existing stub with full contributor guidelines.

## Changes

- **Dev environment setup** — Python 3.10+, venv, pip install steps matching pyproject.toml
- **Optional dependency groups** — voice, memory, browser, brain, full
- **Running tests** — pytest commands, coverage, quick-test mode
- **Code style** — Ruff config details (line-length 100, target py310), Makefile targets
- **PR process** — fork → branch → PR → review (standard FOSS flow)
- **Conventional commits** — examples for feat/fix/docs/refactor/test/chore
- **Bug report & feature request** — links to GitHub issue templates
- **Project structure** — directory overview with descriptions
- **License notice** — AGPL-3.0 contribution agreement
- **Good first issues link** — https://github.com/xbrxr03/clawos/labels/good%20first%20issue

The existing CONTRIBUTING.md was a minimal stub. This replaces it with production-ready contributor documentation that matches the actual project setup (dependencies, test commands, tooling from pyproject.toml and Makefile).