### PR TITLE
docs: add ARCHITECTURE.md link to README + update coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ voice activation, multi-step tool use, 7-layer memory, zero cloud.
 
 [![CI](https://github.com/xbrxr03/clawos/actions/workflows/ci.yml/badge.svg)](https://github.com/xbrxr03/clawos/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+📖 [Architecture Guide](docs/ARCHITECTURE.md)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Telemetry: zero](https://img.shields.io/badge/telemetry-zero-brightgreen.svg)](#zero-telemetry)
-[![Coverage](https://img.shields.io/badge/coverage-30%25-yellow)]
+[![Coverage](https://img.shields.io/badge/coverage-34%25-yellow)]
 
 [Install in 2 minutes](#-quick-start) · [Watch the demos](#-see-it-in-action) · [Read the docs](docs/) · [Join the discussion](https://github.com/xbrxr03/clawos/discussions)
 


### PR DESCRIPTION
## Summary

- Adds 📖 Architecture Guide link to the top of README pointing to `docs/ARCHITECTURE.md`
- Updates coverage badge from 30% → 34% (reflects actual current coverage)

The ARCHITECTURE.md file was already added in #50 (CONTRIBUTING PR). This PR just links to it from the README and fixes the stale badge.