### PR TITLE
chore: add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+# ClawOS .editorconfig — consistent style across all editors
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_size = 4
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.{json,jsonc,json5}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{sh,bash}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.{js,ts,tsx,jsx}]
+indent_size = 2
+
+[*.{css,scss,html}]
+indent_size = 2
+
+[*.toml]
+indent_size = 2


### PR DESCRIPTION
Resolves #52

`.editorconfig` with settings matching existing codebase:
- **Root**: UTF-8, LF, final newline, trim trailing whitespace, 4-space indent
- **Python**: 4-space (matches all existing .py files)
- **YAML/JSON/TOML**: 2-space
- **Shell/JS/TS/CSS/HTML**: 2-space
- **Markdown**: preserve trailing whitespace (markdown line breaks)
- **Makefile**: tabs